### PR TITLE
fix: include path and namespace in purl

### DIFF
--- a/ossbom/converters/cyclonedx_converter.py
+++ b/ossbom/converters/cyclonedx_converter.py
@@ -65,6 +65,9 @@ class CycloneDXConverter:
             env_values = next((prop.value for prop in component.properties if prop.name == "env"), None)
             env = set(DependencyEnv(e) for e in env_values.split(',')) if env_values else set()
             type = component.purl.type if component.purl else component.type.value
+            qualifiers = dict(component.purl.qualifiers) if component.purl and component.purl.qualifiers else {}
+            subpath = component.purl.subpath if component.purl else None
+            namespace = component.purl.namespace if component.purl else None
 
             components.append(
                 OSSBOM_Component(
@@ -72,7 +75,10 @@ class CycloneDXConverter:
                     version=component.version,
                     source=source,
                     env=env,
-                    type=type
+                    type=type,
+                    qualifiers=qualifiers,
+                    subpath=subpath,
+                    namespace=namespace,
                 )
             )
 

--- a/ossbom/converters/test_factory.py
+++ b/ossbom/converters/test_factory.py
@@ -147,3 +147,36 @@ def test_to_cyclonedx_with_component_metadata():
     props = {p.name: p.value for p in cdx_components[0].properties}
     assert props.get("license") == "MIT"
     assert props.get("homepage") == "https://example.com"
+
+
+def test_cyclonedx_roundtrip_preserves_qualifiers_subpath_namespace():
+    """Test that a PURL with path qualifier, subpath, and namespace survives a CycloneDX round-trip."""
+    from ..model.ossbom import OSSBOM
+    from ..model.component import Component
+    from ..model.dependency_env import DependencyEnv
+
+    sbom = OSSBOM(name="Purl Roundtrip Test")
+    comp = Component(
+        name="repo",
+        version="main",
+        source={"github"},
+        env={DependencyEnv.DEV},
+        type="github",
+        namespace="myorg",
+        qualifiers={"path": "examples/ex1"},
+        subpath="sub/dir",
+    )
+    sbom.add_components([comp])
+
+    # Round-trip via CycloneDX object
+    cdx = SBOMConverterFactory.to_cyclonedx(sbom)
+    restored_sbom = SBOMConverterFactory.from_cyclonedx(cdx)
+
+    components = list(restored_sbom.get_components())
+    assert len(components) == 1
+    restored = components[0]
+
+    assert restored.namespace == "myorg"
+    assert restored.qualifiers == {"path": "examples/ex1"}
+    assert restored.subpath == "sub/dir"
+    assert str(restored.get_purl()) == "pkg:github/myorg/repo@main?path=examples/ex1#sub/dir"

--- a/ossbom/model/component.py
+++ b/ossbom/model/component.py
@@ -88,7 +88,7 @@ class Component(Serializable):
         )
 
     def __repr__(self):
-        return f"pkg:{self.type}/{self.name}@{self.version} Source:({', '.join([s for s in self.source])}) Env:({', '.join([t.value for t in self.env])})"
+        return f"{self.get_purl().to_string()} Source:({', '.join([s for s in self.source])}) Env:({', '.join([t.value for t in self.env])})"
 
     def to_dict(self):
         data = {
@@ -124,7 +124,14 @@ class Component(Serializable):
         return Component(name, version, source, env, type, location, metadata, qualifiers, subpath, namespace)
 
     @staticmethod
-    def get_hash(name, version, type, qualifiers: dict | None = None, subpath: str | None = None, namespace: str | None = None):
+    def get_hash(
+        name,
+        version,
+        type,
+        qualifiers: dict | None = None,
+        subpath: str | None = None,
+        namespace: str | None = None,
+    ):
         return hash(PackageURL(
             name=name,
             namespace=namespace,

--- a/ossbom/model/component.py
+++ b/ossbom/model/component.py
@@ -13,7 +13,10 @@ class Component(Serializable):
                  env: Set[DependencyEnv] | None = None,
                  type: str = "library",
                  location: list | None = None,
-                 metadata: dict | None = None) -> None:
+                 metadata: dict | None = None,
+                 qualifiers: dict | None = None,
+                 subpath: str | None = None,
+                 namespace: str | None = None) -> None:
 
         self.name = name
         self.version = version
@@ -22,6 +25,9 @@ class Component(Serializable):
         self.type = type
         self.location = location if location else []
         self.metadata = metadata if metadata else {}
+        self.qualifiers = dict(qualifiers) if qualifiers else {}
+        self.subpath = subpath
+        self.namespace = namespace
 
     @classmethod
     def create(cls,
@@ -31,7 +37,10 @@ class Component(Serializable):
                env: str | None = None,
                type: str = "library",
                location: list | None = None,
-               metadata: dict | None = None
+               metadata: dict | None = None,
+               qualifiers: dict | None = None,
+               subpath: str | None = None,
+               namespace: str | None = None
                ):
 
         source = {source} if source else set()
@@ -39,17 +48,22 @@ class Component(Serializable):
         location = location if location else []
         metadata = metadata if metadata else {}
 
-        return cls(name, version, source, env, type, location, metadata)
+        return cls(name, version, source, env, type, location, metadata, qualifiers, subpath, namespace)
 
     def __hash__(self):
-        # Hash based on the name and version concatenated
         return hash(self.get_purl().to_string())
 
     def __eq__(self, other):
-        # Equality based on name and version
         if not isinstance(other, Component):
             return NotImplemented
-        return self.name == other.name and self.version == other.version
+        return (
+            self.name == other.name
+            and self.version == other.version
+            and self.type == other.type
+            and self.namespace == other.namespace
+            and (self.qualifiers or {}) == (other.qualifiers or {})
+            and self.subpath == other.subpath
+        )
 
     def add_source(self, source):
         self.source.add(source)
@@ -64,34 +78,58 @@ class Component(Serializable):
         self.location.append(location)
 
     def get_purl(self):
-        return PackageURL(name=self.name, version=self.version, type=self.type)
+        return PackageURL(
+            name=self.name,
+            namespace=self.namespace,
+            version=self.version,
+            type=self.type,
+            qualifiers=self.qualifiers or None,
+            subpath=self.subpath,
+        )
 
     def __repr__(self):
         return f"pkg:{self.type}/{self.name}@{self.version} Source:({', '.join([s for s in self.source])}) Env:({', '.join([t.value for t in self.env])})"
 
     def to_dict(self):
-        return {
+        data = {
             "name": self.name,
             "version": self.version,
             "source": list(self.source) if self.source else [],
             "env": [t.value for t in self.env] if self.env else [],
             "type": self.type,
             "location": self.location,
-            "metadata": self.metadata
+            "metadata": self.metadata,
         }
+        if self.namespace:
+            data["namespace"] = self.namespace
+        if self.qualifiers:
+            data["qualifiers"] = dict(self.qualifiers)
+        if self.subpath:
+            data["subpath"] = self.subpath
+        return data
 
     @classmethod
     def from_dict(cls, data):
         name = data['name']  # Not optional
-        version = data['version']  # Not optional
+        version = data['version']  # Not optional
         type = data.get("type", "library")
         env = set(DependencyEnv(e) for e in data.get('env', []))
         source = set(data.get('source', []))
         location = data.get('location', [])
         metadata = data.get('metadata', {})
+        qualifiers = data.get('qualifiers') or {}
+        subpath = data.get('subpath')
+        namespace = data.get('namespace')
 
-        return Component(name, version, source, env, type, location, metadata)
+        return Component(name, version, source, env, type, location, metadata, qualifiers, subpath, namespace)
 
     @staticmethod
-    def get_hash(name, version, type):
-        return hash(PackageURL(name=name, version=version, type=type).to_string())
+    def get_hash(name, version, type, qualifiers: dict | None = None, subpath: str | None = None, namespace: str | None = None):
+        return hash(PackageURL(
+            name=name,
+            namespace=namespace,
+            version=version,
+            type=type,
+            qualifiers=qualifiers or None,
+            subpath=subpath,
+        ).to_string())

--- a/ossbom/model/minicomponent.py
+++ b/ossbom/model/minicomponent.py
@@ -15,11 +15,14 @@ class MiniComponent(Serializable):
                  ) -> None:
 
         self.name = purl.name
+        self.namespace = purl.namespace
         self.version = purl.version
         self.source = source if source else set()
         self.env = env if env else set()
         self.type = purl.type
         self.location = location if location else []
+        self.qualifiers = dict(purl.qualifiers) if purl.qualifiers else {}
+        self.subpath = purl.subpath
 
     @classmethod
     def create(cls,
@@ -32,18 +35,23 @@ class MiniComponent(Serializable):
         source = {source} if source else set()
         env = {DependencyEnv(env)} if env else set()
         location = location if location else []
-        
+
         return cls(purl, source, env, location)
 
     def __hash__(self):
-        # Hash based on the name and version concatenated
         return hash(self.get_purl().to_string())
 
     def __eq__(self, other):
-        # Equality based on name and version
         if not isinstance(other, MiniComponent):
             return NotImplemented
-        return self.name == other.name and self.version == other.version
+        return (
+            self.name == other.name
+            and self.version == other.version
+            and self.type == other.type
+            and self.namespace == other.namespace
+            and (self.qualifiers or {}) == (other.qualifiers or {})
+            and self.subpath == other.subpath
+        )
 
     def add_source(self, source):
         self.source.add(source)
@@ -55,7 +63,14 @@ class MiniComponent(Serializable):
         return self.type
 
     def get_purl(self):
-        return PackageURL(name=self.name, version=self.version, type=self.type)
+        return PackageURL(
+            name=self.name,
+            namespace=self.namespace,
+            version=self.version,
+            type=self.type,
+            qualifiers=self.qualifiers or None,
+            subpath=self.subpath,
+        )
 
     def __repr__(self):
         return f"pkg:{self.type}/{self.name}@{self.version} Source:({', '.join([s for s in self.source])}) Env:({', '.join([t.value for t in self.env])})"
@@ -83,12 +98,41 @@ class MiniComponent(Serializable):
         return cls(purl, source, env, location)
 
     @staticmethod
-    def get_hash(name, version, type):
-        return hash(PackageURL(name=name, version=version, type=type).to_string())
+    def get_hash(name, version, type, qualifiers: dict | None = None, subpath: str | None = None, namespace: str | None = None):
+        return hash(PackageURL(
+            name=name,
+            namespace=namespace,
+            version=version,
+            type=type,
+            qualifiers=qualifiers or None,
+            subpath=subpath,
+        ).to_string())
 
     @classmethod
     def from_component(cls, component):
-        return cls(PackageURL(name=component.name, version=component.version, type=component.type), component.source, component.env, component.location)
+        return cls(
+            PackageURL(
+                name=component.name,
+                namespace=getattr(component, "namespace", None),
+                version=component.version,
+                type=component.type,
+                qualifiers=getattr(component, "qualifiers", None) or None,
+                subpath=getattr(component, "subpath", None),
+            ),
+            component.source,
+            component.env,
+            component.location,
+        )
 
     def to_component(self):
-        return Component(name=self.name, version=self.version, type=self.type, source=self.source, env=self.env, location=self.location)
+        return Component(
+            name=self.name,
+            version=self.version,
+            type=self.type,
+            source=self.source,
+            env=self.env,
+            location=self.location,
+            qualifiers=self.qualifiers or None,
+            subpath=self.subpath,
+            namespace=self.namespace,
+        )

--- a/ossbom/model/minicomponent.py
+++ b/ossbom/model/minicomponent.py
@@ -73,7 +73,7 @@ class MiniComponent(Serializable):
         )
 
     def __repr__(self):
-        return f"pkg:{self.type}/{self.name}@{self.version} Source:({', '.join([s for s in self.source])}) Env:({', '.join([t.value for t in self.env])})"
+        return f"{str(self.get_purl())} Source:({', '.join([s for s in self.source])}) Env:({', '.join([t.value for t in self.env])})"
 
     def to_dict(self):
         data = {
@@ -98,7 +98,14 @@ class MiniComponent(Serializable):
         return cls(purl, source, env, location)
 
     @staticmethod
-    def get_hash(name, version, type, qualifiers: dict | None = None, subpath: str | None = None, namespace: str | None = None):
+    def get_hash(
+        name,
+        version,
+        type,
+        qualifiers: dict | None = None,
+        subpath: str | None = None,
+        namespace: str | None = None,
+    ):
         return hash(PackageURL(
             name=name,
             namespace=namespace,

--- a/ossbom/model/test_component.py
+++ b/ossbom/model/test_component.py
@@ -198,3 +198,36 @@ def test_component_eq_with_non_component():
     result = comp.__eq__("not-a-component")
 
     assert result is NotImplemented
+
+
+def test_component_preserves_path_qualifier():
+    comp = Component.create(
+        name="repo", version="main", type="github",
+        qualifiers={"path": "examples/ex1"},
+    )
+
+    assert str(comp.get_purl()) == "pkg:github/repo@main?path=examples/ex1"
+
+
+def test_component_path_qualifier_roundtrip_via_dict():
+    comp = Component.create(
+        name="repo", version="main", type="github",
+        qualifiers={"path": "examples/ex1"},
+        subpath="sub/dir",
+    )
+
+    restored = Component.from_dict(comp.to_dict())
+
+    assert restored.qualifiers == {"path": "examples/ex1"}
+    assert restored.subpath == "sub/dir"
+    assert str(restored.get_purl()) == "pkg:github/repo@main?path=examples/ex1#sub/dir"
+
+
+def test_component_eq_distinguishes_path_qualifier():
+    a = Component.create(name="repo", version="main", type="github",
+                         qualifiers={"path": "ex1"})
+    b = Component.create(name="repo", version="main", type="github",
+                         qualifiers={"path": "ex2"})
+
+    assert a != b
+    assert hash(a) != hash(b)

--- a/ossbom/model/test_component.py
+++ b/ossbom/model/test_component.py
@@ -231,3 +231,41 @@ def test_component_eq_distinguishes_path_qualifier():
 
     assert a != b
     assert hash(a) != hash(b)
+
+
+def test_component_namespace_in_purl():
+    """Test that namespace is included in the PURL for Component."""
+    comp = Component.create(
+        name="repo", version="1.0.0", type="github",
+        namespace="myorg",
+    )
+
+    assert str(comp.get_purl()) == "pkg:github/myorg/repo@1.0.0"
+
+
+def test_component_namespace_roundtrip_via_dict():
+    """Test that namespace survives to_dict/from_dict round-trip for Component."""
+    comp = Component.create(
+        name="repo", version="1.0.0", type="github",
+        namespace="myorg",
+        qualifiers={"path": "src/lib"},
+        subpath="sub/dir",
+    )
+
+    restored = Component.from_dict(comp.to_dict())
+
+    assert restored.namespace == "myorg"
+    assert restored.qualifiers == {"path": "src/lib"}
+    assert restored.subpath == "sub/dir"
+    assert str(restored.get_purl()) == "pkg:github/myorg/repo@1.0.0?path=src/lib#sub/dir"
+
+
+def test_component_eq_distinguishes_namespace():
+    """Test that Components with different namespaces are not equal."""
+    a = Component.create(name="repo", version="1.0.0", type="github",
+                         namespace="org-a")
+    b = Component.create(name="repo", version="1.0.0", type="github",
+                         namespace="org-b")
+
+    assert a != b
+    assert hash(a) != hash(b)

--- a/ossbom/model/test_minicomponent.py
+++ b/ossbom/model/test_minicomponent.py
@@ -184,3 +184,55 @@ def test_MiniComponent_to_component():
     assert component.type == mini.type
     assert component.source == mini.source
     assert component.env == mini.env
+
+
+def test_MiniComponent_preserves_path_qualifier():
+    purl = PackageURL.from_string("pkg:github/owner/repo@main?path=examples/ex1")
+    comp = MiniComponent(purl=purl)
+
+    assert comp.qualifiers == {"path": "examples/ex1"}
+    assert str(comp.get_purl()) == "pkg:github/owner/repo@main?path=examples/ex1"
+
+
+def test_MiniComponent_to_dict_emits_path_qualifier():
+    purl = PackageURL.from_string("pkg:github/owner/repo@main?path=examples/ex1")
+    comp = MiniComponent(purl=purl)
+
+    assert comp.to_dict()["purl"] == "pkg:github/owner/repo@main?path=examples/ex1"
+
+
+def test_MiniComponent_from_dict_roundtrips_path_qualifier():
+    data = {
+        "purl": "pkg:github/owner/repo@main?path=examples/ex1",
+        "source": [],
+        "env": [],
+    }
+    comp = MiniComponent.from_dict(data)
+
+    assert comp.qualifiers == {"path": "examples/ex1"}
+    assert comp.to_dict()["purl"] == data["purl"]
+
+
+def test_MiniComponent_eq_distinguishes_path_qualifier():
+    a = MiniComponent(purl=PackageURL.from_string("pkg:github/owner/repo@main?path=ex1"))
+    b = MiniComponent(purl=PackageURL.from_string("pkg:github/owner/repo@main?path=ex2"))
+
+    assert a != b
+    assert hash(a) != hash(b)
+
+
+def test_MiniComponent_from_component_preserves_path_qualifier():
+    comp = Component(name="repo", version="main", type="github",
+                     qualifiers={"path": "examples/ex1"})
+    mini = MiniComponent.from_component(comp)
+
+    assert mini.qualifiers == {"path": "examples/ex1"}
+    assert str(mini.get_purl()) == "pkg:github/repo@main?path=examples/ex1"
+
+
+def test_MiniComponent_to_component_preserves_path_qualifier():
+    mini = MiniComponent(purl=PackageURL.from_string("pkg:github/owner/repo@main?path=ex1"))
+    comp = mini.to_component()
+
+    assert comp.qualifiers == {"path": "ex1"}
+    assert str(comp.get_purl()) == "pkg:github/owner/repo@main?path=ex1"


### PR DESCRIPTION
Purl was not respecting the path, which is constructed via ?path= for ossbom and for subpath on components for CycloneDX. I also spotted namespace was not included, and that can be used for github repos.